### PR TITLE
Randomization related

### DIFF
--- a/src/main/java/com/demoxin/minecraft/moreenchants/charm/ItemCharm.java
+++ b/src/main/java/com/demoxin/minecraft/moreenchants/charm/ItemCharm.java
@@ -128,10 +128,11 @@ public class ItemCharm extends Item
 		if(fEvent.entity.worldObj.rand.nextInt(rarity) > 1)
 			return;
 		
-		int dropTexture = (fEvent.entity.worldObj.rand.nextInt(icons.length)-1);
+		// rand.nextInt(icons.length) yields [0..8) which fit perfectly into the icon array
+		int dropTexture = (fEvent.entity.worldObj.rand.nextInt(icons.length));
 		ItemStack dropCharm = new ItemStack(this, 1, dropTexture);
 		
-		Enchantment dropEnchant = validEnchants.get(fEvent.entity.worldObj.rand.nextInt(validEnchants.size())+1);
+		Enchantment dropEnchant = validEnchants.get(fEvent.entity.worldObj.rand.nextInt(validEnchants.size())); // similar
 		dropCharm.addEnchantment(dropEnchant, 1);
 		fEvent.drops.add(new EntityItem(fEvent.entity.worldObj, fEvent.entity.posX, fEvent.entity.posY, fEvent.entity.posZ, dropCharm));
 	}


### PR DESCRIPTION
The icons array of length 8 would accept indexes range between [0..8). While rand.nextInt(8) is giving the exactly same range [0..8), no further adjustment to the index should be required. The similar logic could be applied to the validEnchants list as well.
